### PR TITLE
Abstract storage mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,30 @@ The Sass file should import the variables defined in `styles/_variables.scss` an
 }
 ```
 
+# Using a different storage engine
+
+Handsome stores widget data in redis by default, but it uses [cacheman](https://github.com/cayasso/cacheman) as an interface.
+
+This means that you can use any storage engine that cacheman supports. [Here are the available storage engines](https://github.com/cayasso/cacheman#supported-engines)
+
+To switch engines, install the corresponding cacheman package (e.g. `cacheman-mongo`) for MongoDB and then update the storage options in `config.js` to use the new engine:
+
+```
+var Cacheman = require('cacheman');
+
+var storage_options = {
+  engine: 'mongo',
+  port: 9999,
+  host: '127.0.0.1',
+  username: 'user',
+  ...
+};
+
+exports.getStorage = function() {
+  return new Cacheman('handsome', storage_options)
+};
+```
+
 # How does Handsome differ from Dashing?
 
 Handsome's front-end is powered by [React](https://facebook.github.io/react/), while Dashing's is powered by [Batman.js](http://batmanjs.org/)

--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ var app = express();
 var moment = require('moment');
 
 var config = require(__dirname + '/config.js');
-var redis = config.getRedisClient();
+var storage = config.getStorage();
 
 const path = require('path');
 
@@ -22,7 +22,7 @@ app.get('/:dashboard', function(req, res) {
 });
 
 app.get('/widgets/:widget.json', function(req, res) {
-  redis.get(req.params.widget, function(err, reply) {
+  storage.get(req.params.widget, function(err, reply) {
     if(err) {
       res.json({'error': err});
     } else {

--- a/config.js
+++ b/config.js
@@ -1,15 +1,12 @@
-var redis = require('redis');
+var Cacheman = require('cacheman');
 
-var config = {
-  redis_server_host: process.env.REDIS_SERVER_HOST || "127.0.0.1",
-  redis_server_port: process.env.REDIS_SERVER_PORT || 6379,
-  redis_server_password: process.env.REDIS_SERVER_PASSWORD || undefined
+var storage_options = {
+  engine: 'redis',
+  port: process.env.REDIS_SERVER_PORT || 6379,
+  host: process.env.REDIS_SERVER_HOST || "127.0.0.1",
+  password: process.env.REDIS_SERVER_PASSWORD || undefined
 };
 
-exports.getRedisClient = function() {
-  var options = {
-      password: config.redis_server_password
-  };
-
-  return redis.createClient(config.redis_server_port, config.redis_server_host, options);
+exports.getStorage = function() {
+  return new Cacheman('handsome', storage_options)
 };

--- a/jobs.js
+++ b/jobs.js
@@ -1,5 +1,5 @@
 var config = require(__dirname + '/config.js');
-var redis = config.getRedisClient();
+var storage = config.getStorage();
 
 var moment = require('moment');
 
@@ -7,7 +7,7 @@ var jobs = require('require-all')(__dirname + '/jobs');
 
 function update_widget(name, data, next_time) {
   console.log("updating widget: " + name);
-  redis.set(name, JSON.stringify({
+  storage.set(name, JSON.stringify({
     payload: data,
     next_time: next_time
   }), function(err, res) {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "cacheman": "^2.2.1",
+    "cacheman-redis": "^1.1.2",
     "css-loader": "^0.23.1",
     "express": "^4.13.4",
     "express-handlebars": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "cacheman": "^2.2.1",
     "css-loader": "^0.23.1",
     "express": "^4.13.4",
     "express-handlebars": "^3.0.0",


### PR DESCRIPTION
Resolves #8 by adding [cacheman](https://github.com/cayasso/cacheman) as an interface layer in front of redis. Implicitly adds support for in-memory, file-based, and MongoDB storage options.